### PR TITLE
On sonarqube 8.5.1 api differences

### DIFF
--- a/src/SonarQube.Net/Models/QualityGatesProjectStatus.cs
+++ b/src/SonarQube.Net/Models/QualityGatesProjectStatus.cs
@@ -2,11 +2,16 @@
 
 namespace SonarQube.Net.Models
 {
-	public class QualityGatesProjectStatus
-	{
-		public string Status { get; set; }
-		public bool? IgnoredConditions { get; set; }
-		public IEnumerable<QualityGateCondition> Conditions { get; set; }
-		public IEnumerable<QualityGatePeriod> Periods { get; set; }
-	}
+    public class QualityGatesProjectStatus
+    {
+        public QualityGatesProjectStatusData ProjectStatus { get; set; }
+    }
+
+    public class QualityGatesProjectStatusData
+    {
+        public string Status { get; set; }
+        public bool? IgnoredConditions { get; set; }
+        public IEnumerable<QualityGateCondition> Conditions { get; set; }
+        public IEnumerable<QualityGatePeriod> Periods { get; set; }
+    }
 }


### PR DESCRIPTION
On newer versions of the sonarqube api the quality gate status data is nested on a property named "projectStatus". I forked the project and created a quickfix to meet my needs. Feel free to merge this if you find it to be useful.