### PR TITLE
sending data for api/settings/set inside POST body

### DIFF
--- a/src/SonarQube.Net/Settings/SonarQubeClient.cs
+++ b/src/SonarQube.Net/Settings/SonarQubeClient.cs
@@ -48,9 +48,9 @@ namespace SonarQube.Net
 				[nameof(values)] = values
 			};
 
+			//sending data as application/x-www-form-urlencoded in order to support large values arrays
 			var response = await GetSettingsUrl("set")
-				.SetQueryParams(queryParamValues)
-				.PostAsync(s_emptyHttpContent)
+				.PostUrlEncodedAsync(queryParamValues)
 				.ConfigureAwait(false);
 
 			return await HandleResponseAsync(response).ConfigureAwait(false);


### PR DESCRIPTION
Hello.

I'd like to propose this change to support sending a large number of settings values to Sonarqube API. Without this fix I was hitting GET URL string limit when using API to set `sonar.inclusions` setting to a list of files in a big pull-request. Lucky for me, it turns out, that API supports reading request parameters from form Body and query string, like good old ASP.NET 😄 